### PR TITLE
feat(sec-headers): Security headers uitility - fix

### DIFF
--- a/src/security-headers/security-headers.test.ts
+++ b/src/security-headers/security-headers.test.ts
@@ -19,7 +19,62 @@ test('should return an array of headers with the correct values', async () => {
         {
           key: 'Content-Security-Policy',
           value:
-            "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: scripts.com; style-src 'self' 'unsafe-inline' blob: data: styles.com; img-src 'self' blob: data: images.com; font-src 'self' blob: data: fonts.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self' iframe.com; connect-src 'self' connect.com; media-src 'self' media.com; report-uri reports.com; report-to default;",
+            "default-src 'self'; script-src 'self' unsafe-eval unsafe-inline blob: scripts.com; style-src 'self' unsafe-inline blob: data: styles.com; img-src 'self' blob: data: images.com; font-src 'self' blob: data: fonts.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self' iframe.com; connect-src 'self' connect.com; media-src 'self' media.com; report-uri reports.com; report-to default;",
+        },
+        {
+          key: 'X-Frame-Options',
+          value: 'DENY',
+        },
+        {
+          key: 'X-Content-Type-Options',
+          value: 'nosniff',
+        },
+        {
+          key: 'Referrer-Policy',
+          value: 'origin-when-cross-origin',
+        },
+        {
+          key: 'Strict-Transport-Security',
+          value: 'max-age=12345; includeSubDomains',
+        },
+        {
+          key: 'Feature-Policy',
+          value: "geolocation 'none'",
+        },
+      ],
+    },
+  ];
+
+  const headersGenerator = securityHeaders(cspWhitelist, {
+    allowUnsafeEval: true,
+    allowUnsafeInline: true,
+    stsMaxAge: 12345,
+  });
+
+  const result = await headersGenerator();
+  expect(result).toEqual(expectedHeaders);
+});
+
+test('should return an array of headers with the correct values when options are not provided', async () => {
+  const cspWhitelist: CSPWhitelist = {
+    images: ['images.com'],
+    scripts: ['scripts.com'],
+    iframe: ['iframe.com'],
+    connect: ['connect.com'],
+    styles: ['styles.com'],
+    fonts: ['fonts.com'],
+    reports: ['reports.com'],
+    media: ['media.com'],
+  };
+
+  const expectedHeaders = [
+    {
+      source: '/(.*)',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value:
+            "default-src 'self'; script-src 'self'   blob: scripts.com; style-src 'self'  blob: data: styles.com; img-src 'self' blob: data: images.com; font-src 'self' blob: data: fonts.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self' iframe.com; connect-src 'self' connect.com; media-src 'self' media.com; report-uri reports.com; report-to default;",
         },
         {
           key: 'X-Frame-Options',
@@ -49,4 +104,43 @@ test('should return an array of headers with the correct values', async () => {
 
   const result = await headersGenerator();
   expect(result).toEqual(expectedHeaders);
+});
+
+test('should return header when no params passed in', async () => {
+  const headersGenerator = securityHeaders();
+  expect(headersGenerator).toBeDefined();
+
+  const result = await headersGenerator();
+  expect(result).toEqual([
+    {
+      source: '/(.*)',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value:
+            "default-src 'self'; script-src 'self'   blob: ; style-src 'self'  blob: data: ; img-src 'self' blob: data: ; font-src 'self' blob: data: ; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self' ; connect-src 'self' ; media-src 'self' ; report-uri ; report-to default;",
+        },
+        {
+          key: 'X-Frame-Options',
+          value: 'DENY',
+        },
+        {
+          key: 'X-Content-Type-Options',
+          value: 'nosniff',
+        },
+        {
+          key: 'Referrer-Policy',
+          value: 'origin-when-cross-origin',
+        },
+        {
+          key: 'Strict-Transport-Security',
+          value: 'max-age=31536000; includeSubDomains',
+        },
+        {
+          key: 'Feature-Policy',
+          value: "geolocation 'none'",
+        },
+      ],
+    },
+  ]);
 });


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced `securityHeaders` utility with additional options and validations.

- Added new tests for various `securityHeaders` configurations.

- Improved `CSPWhitelist` type to support optional properties.

- Refactored `generateCSPHeader` to handle dynamic options.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-headers.test.ts</strong><dd><code>Add comprehensive tests for `securityHeaders` utility</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/security-headers/security-headers.test.ts

<li>Added tests for <code>securityHeaders</code> with and without options.<br> <li> Verified headers generation for various configurations.<br> <li> Included edge cases for default and empty parameters.


</details>


  </td>
  <td><a href="https://github.com/VinayakHegde/smart-kit-nextjs/pull/20/files#diff-89af62e49d0b94fa6f8d377a56aee3ae0305d76b1c5a350e5e0a79d7bbad36ab">+95/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-headers.ts</strong><dd><code>Enhance `securityHeaders` utility with options and validations</code></dd></summary>
<hr>

src/security-headers/security-headers.ts

<li>Enhanced <code>CSPWhitelist</code> type to allow optional properties.<br> <li> Added <code>validateWhitelist</code> to enforce entry limits.<br> <li> Updated <code>generateCSPHeader</code> to handle dynamic options.<br> <li> Refactored <code>securityHeaders</code> to support new options and defaults.


</details>


  </td>
  <td><a href="https://github.com/VinayakHegde/smart-kit-nextjs/pull/20/files#diff-bbc1cf851394dfa1a83bdca578ab1cb27a23a56dacb01974589ccd2ed71d10e8">+54/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information